### PR TITLE
add context to all request calls

### DIFF
--- a/sms77api/analytics.go
+++ b/sms77api/analytics.go
@@ -1,6 +1,7 @@
 package sms77api
 
 import (
+	"context"
 	"encoding/json"
 )
 
@@ -39,7 +40,11 @@ const (
 )
 
 func (api *AnalyticsResource) Get(p *AnalyticsParams) (o []Analytics, err error) {
-	res, err := api.client.request("analytics", "GET", p)
+	return api.GetContext(context.Background(), p)
+}
+
+func (api *AnalyticsResource) GetContext(ctx context.Context, p *AnalyticsParams) (o []Analytics, err error) {
+	res, err := api.client.request(ctx, "analytics", "GET", p)
 	if err != nil {
 		return nil, err
 	}

--- a/sms77api/balance.go
+++ b/sms77api/balance.go
@@ -1,11 +1,18 @@
 package sms77api
 
-import "strconv"
+import (
+	"context"
+	"strconv"
+)
 
 type BalanceResource resource
 
 func (api *BalanceResource) Get() (*float64, error) {
-	res, err := api.client.request("balance", "GET", nil)
+	return api.GetContext(context.Background())
+}
+
+func (api *BalanceResource) GetContext(ctx context.Context) (*float64, error) {
+	res, err := api.client.request(ctx, "balance", "GET", nil)
 
 	if err != nil {
 		return nil, err

--- a/sms77api/contacts.go
+++ b/sms77api/contacts.go
@@ -1,6 +1,9 @@
 package sms77api
 
-import "encoding/json"
+import (
+	"context"
+	"encoding/json"
+)
 
 type ContactsResource resource
 
@@ -114,16 +117,24 @@ func newContactsEditJsonApiParams(p ContactEditParams, json bool) contactsEditJs
 	}
 }
 
-func (api *ContactsResource) request(method HttpMethod, params interface{}) (string, error) {
-	return api.client.request("contacts", string(method), params)
+func (api *ContactsResource) request(ctx context.Context, method HttpMethod, params interface{}) (string, error) {
+	return api.client.request(ctx, "contacts", string(method), params)
 }
 
 func (api *ContactsResource) ReadCsv(p ContactsReadParams) (string, error) {
-	return api.request(HttpMethodGet, newReadApiParams(p, false))
+	return api.ReadCsvContext(context.Background(), p)
+}
+
+func (api *ContactsResource) ReadCsvContext(ctx context.Context, p ContactsReadParams) (string, error) {
+	return api.request(ctx, HttpMethodGet, newReadApiParams(p, false))
 }
 
 func (api *ContactsResource) ReadJson(p ContactsReadParams) (a []Contact, e error) {
-	s, e := api.request(HttpMethodGet, newReadApiParams(p, true))
+	return api.ReadJsonContext(context.Background(), p)
+}
+
+func (api *ContactsResource) ReadJsonContext(ctx context.Context, p ContactsReadParams) (a []Contact, e error) {
+	s, e := api.request(ctx, HttpMethodGet, newReadApiParams(p, true))
 
 	if nil != e {
 		return
@@ -135,11 +146,19 @@ func (api *ContactsResource) ReadJson(p ContactsReadParams) (a []Contact, e erro
 }
 
 func (api *ContactsResource) CreateCsv() (string, error) {
-	return api.request(HttpMethodPost, newContactsCreateApiParams(false))
+	return api.CreateCsvContext(context.Background())
+}
+
+func (api *ContactsResource) CreateCsvContext(ctx context.Context) (string, error) {
+	return api.request(ctx, HttpMethodPost, newContactsCreateApiParams(false))
 }
 
 func (api *ContactsResource) CreateJson() (o ContactsCreateJsonResponse, e error) {
-	s, e := api.request(HttpMethodGet, newContactsCreateApiParams(true))
+	return api.CreateJsonContext(context.Background())
+}
+
+func (api *ContactsResource) CreateJsonContext(ctx context.Context) (o ContactsCreateJsonResponse, e error) {
+	s, e := api.request(ctx, HttpMethodGet, newContactsCreateApiParams(true))
 
 	e = json.Unmarshal([]byte(s), &o)
 
@@ -147,11 +166,19 @@ func (api *ContactsResource) CreateJson() (o ContactsCreateJsonResponse, e error
 }
 
 func (api *ContactsResource) DeleteCsv(p ContactsDeleteParams) (string, error) {
-	return api.request(HttpMethodPost, newContactsDeleteApiParams(p, false))
+	return api.DeleteCsvContext(context.Background(), p)
+}
+
+func (api *ContactsResource) DeleteCsvContext(ctx context.Context, p ContactsDeleteParams) (string, error) {
+	return api.request(ctx, HttpMethodPost, newContactsDeleteApiParams(p, false))
 }
 
 func (api *ContactsResource) DeleteJson(p ContactsDeleteParams) (o ContactsDeleteJsonResponse, e error) {
-	s, e := api.request(HttpMethodGet, newContactsDeleteApiParams(p, true))
+	return api.DeleteJsonContext(context.Background(), p)
+}
+
+func (api *ContactsResource) DeleteJsonContext(ctx context.Context, p ContactsDeleteParams) (o ContactsDeleteJsonResponse, e error) {
+	s, e := api.request(ctx, HttpMethodGet, newContactsDeleteApiParams(p, true))
 
 	e = json.Unmarshal([]byte(s), &o)
 
@@ -159,11 +186,19 @@ func (api *ContactsResource) DeleteJson(p ContactsDeleteParams) (o ContactsDelet
 }
 
 func (api *ContactsResource) EditCsv(p ContactEditParams) (string, error) {
-	return api.request(HttpMethodGet, newContactsEditJsonApiParams(p, false))
+	return api.EditCsvContext(context.Background(), p)
+}
+
+func (api *ContactsResource) EditCsvContext(ctx context.Context, p ContactEditParams) (string, error) {
+	return api.request(ctx, HttpMethodGet, newContactsEditJsonApiParams(p, false))
 }
 
 func (api *ContactsResource) EditJson(p ContactEditParams) (o ContactsEditJsonResponse, e error) {
-	s, e := api.request(HttpMethodGet, newContactsEditJsonApiParams(p, true))
+	return api.EditJsonContext(context.Background(), p)
+}
+
+func (api *ContactsResource) EditJsonContext(ctx context.Context, p ContactEditParams) (o ContactsEditJsonResponse, e error) {
+	s, e := api.request(ctx, HttpMethodGet, newContactsEditJsonApiParams(p, true))
 
 	e = json.Unmarshal([]byte(s), &o)
 

--- a/sms77api/hooks.go
+++ b/sms77api/hooks.go
@@ -1,6 +1,9 @@
 package sms77api
 
-import "encoding/json"
+import (
+	"context"
+	"encoding/json"
+)
 
 type HookEventType string
 
@@ -59,12 +62,16 @@ type HooksSubscribeResponse struct {
 type HooksResource resource
 
 func (api *HooksResource) Request(p HooksParams) (interface{}, error) {
+	return api.RequestContext(context.Background(), p)
+}
+
+func (api *HooksResource) RequestContext(ctx context.Context, p HooksParams) (interface{}, error) {
 	method := "POST"
 	if p.Action == HooksActionRead {
 		method = "GET"
 	}
 
-	res, err := api.client.request("hooks", method, p)
+	res, err := api.client.request(ctx, "hooks", method, p)
 
 	if err != nil {
 		return nil, err

--- a/sms77api/journal.go
+++ b/sms77api/journal.go
@@ -1,6 +1,7 @@
 package sms77api
 
 import (
+	"context"
 	"encoding/json"
 )
 
@@ -68,7 +69,11 @@ func BuildJournalParams(journalType JournalType, p *JournalParams) *JournalParam
 }
 
 func (api *JournalResource) Inbound(p *JournalParams) ([]JournalInbound, error) {
-	res, err := api.client.request("journal", "GET", BuildJournalParams(JournalTypeInbound, p))
+	return api.InboundContext(context.Background(), p)
+}
+
+func (api *JournalResource) InboundContext(ctx context.Context, p *JournalParams) ([]JournalInbound, error) {
+	res, err := api.client.request(ctx, "journal", "GET", BuildJournalParams(JournalTypeInbound, p))
 
 	if err != nil {
 		return nil, err
@@ -84,7 +89,11 @@ func (api *JournalResource) Inbound(p *JournalParams) ([]JournalInbound, error) 
 }
 
 func (api *JournalResource) Outbound(p *JournalParams) ([]JournalOutbound, error) {
-	res, err := api.client.request("journal", "GET", BuildJournalParams(JournalTypeOutbound, p))
+	return api.OutboundContext(context.Background(), p)
+}
+
+func (api *JournalResource) OutboundContext(ctx context.Context, p *JournalParams) ([]JournalOutbound, error) {
+	res, err := api.client.request(ctx, "journal", "GET", BuildJournalParams(JournalTypeOutbound, p))
 
 	if err != nil {
 		return nil, err
@@ -100,7 +109,11 @@ func (api *JournalResource) Outbound(p *JournalParams) ([]JournalOutbound, error
 }
 
 func (api *JournalResource) Replies(p *JournalParams) ([]JournalReplies, error) {
-	res, err := api.client.request("journal", "GET", BuildJournalParams(JournalTypeReplies, p))
+	return api.RepliesContext(context.Background(), p)
+}
+
+func (api *JournalResource) RepliesContext(ctx context.Context, p *JournalParams) ([]JournalReplies, error) {
+	res, err := api.client.request(ctx, "journal", "GET", BuildJournalParams(JournalTypeReplies, p))
 
 	if err != nil {
 		return nil, err
@@ -116,7 +129,11 @@ func (api *JournalResource) Replies(p *JournalParams) ([]JournalReplies, error) 
 }
 
 func (api *JournalResource) Voice(p *JournalParams) ([]JournalVoice, error) {
-	res, err := api.client.request("journal", "GET", BuildJournalParams(JournalTypeVoice, p))
+	return api.VoiceContext(context.Background(), p)
+}
+
+func (api *JournalResource) VoiceContext(ctx context.Context, p *JournalParams) ([]JournalVoice, error) {
+	res, err := api.client.request(ctx, "journal", "GET", BuildJournalParams(JournalTypeVoice, p))
 
 	if err != nil {
 		return nil, err

--- a/sms77api/lookup.go
+++ b/sms77api/lookup.go
@@ -1,6 +1,9 @@
 package sms77api
 
-import "encoding/json"
+import (
+	"context"
+	"encoding/json"
+)
 
 type Carrier struct {
 	Country     string `json:"country"`
@@ -76,7 +79,11 @@ type Mnp struct {
 type LookupResource resource
 
 func (api *LookupResource) Post(p LookupParams) (interface{}, error) {
-	res, err := api.client.request("lookup", "GET", p)
+	return api.PostContext(context.Background(), p)
+}
+
+func (api *LookupResource) PostContext(ctx context.Context, p LookupParams) (interface{}, error) {
+	res, err := api.client.request(ctx, "lookup", "GET", p)
 
 	if err != nil {
 		return nil, err

--- a/sms77api/pricing.go
+++ b/sms77api/pricing.go
@@ -1,6 +1,9 @@
 package sms77api
 
-import "encoding/json"
+import (
+	"context"
+	"encoding/json"
+)
 
 type PricingResource resource
 
@@ -85,7 +88,11 @@ const (
 const EndpointPricing = "pricing"
 
 func (api *PricingResource) Csv(p PricingParams) (string, error) {
-	res, err := api.client.request(EndpointPricing, "GET", PricingApiParams{
+	return api.CsvContext(context.Background(), p)
+}
+
+func (api *PricingResource) CsvContext(ctx context.Context, p PricingParams) (string, error) {
+	res, err := api.client.request(ctx, EndpointPricing, "GET", PricingApiParams{
 		PricingParams: p,
 		Format:        PricingFormatCsv,
 	})
@@ -98,7 +105,10 @@ func (api *PricingResource) Csv(p PricingParams) (string, error) {
 }
 
 func (api *PricingResource) Json(p PricingParams) (*PricingResponse, error) {
-	res, err := api.client.request(EndpointPricing, "GET", PricingApiParams{PricingParams: p})
+	return api.JsonContext(context.Background(), p)
+}
+func (api *PricingResource) JsonContext(ctx context.Context, p PricingParams) (*PricingResponse, error) {
+	res, err := api.client.request(ctx, EndpointPricing, "GET", PricingApiParams{PricingParams: p})
 
 	if err != nil {
 		return nil, err

--- a/sms77api/sms.go
+++ b/sms77api/sms.go
@@ -1,6 +1,9 @@
 package sms77api
 
-import "encoding/json"
+import (
+	"context"
+	"encoding/json"
+)
 
 type SmsFile struct {
 	Contents string  `json:"contents"`
@@ -59,8 +62,8 @@ type SmsResponseMessage struct {
 	Text      string    `json:"text"`
 }
 
-func (api *SmsResource) request(p interface{}) (*string, error) {
-	res, err := api.client.request("sms", "POST", p)
+func (api *SmsResource) request(ctx context.Context, p interface{}) (*string, error) {
+	res, err := api.client.request(ctx, "sms", "POST", p)
 
 	if err != nil {
 		return nil, err
@@ -70,16 +73,23 @@ func (api *SmsResource) request(p interface{}) (*string, error) {
 }
 
 func (api *SmsResource) Text(p SmsTextParams) (res *string, err error) {
-	return api.request(p)
+	return api.TextContext(context.Background(), p)
+}
+
+func (api *SmsResource) TextContext(ctx context.Context, p SmsTextParams) (res *string, err error) {
+	return api.request(ctx, p)
 }
 
 func (api *SmsResource) Json(p SmsBaseParams) (o *SmsResponse, err error) {
+	return api.JsonContext(context.Background(), p)
+}
+func (api *SmsResource) JsonContext(ctx context.Context, p SmsBaseParams) (o *SmsResponse, err error) {
 	type SmsJsonParams struct {
 		SmsBaseParams
 		Json bool `json:"json,omitempty"`
 	}
 
-	res, err := api.request(SmsJsonParams{
+	res, err := api.request(ctx, SmsJsonParams{
 		SmsBaseParams: p,
 		Json:          true,
 	})

--- a/sms77api/sms77api.go
+++ b/sms77api/sms77api.go
@@ -1,6 +1,7 @@
 package sms77api
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -109,15 +110,15 @@ func New(options Options) *Sms77API {
 	return c
 }
 
-func (api *Sms77API) get(endpoint string, data map[string]interface{}) (string, error) {
-	return api.request(endpoint, http.MethodGet, data)
+func (api *Sms77API) get(ctx context.Context, endpoint string, data map[string]interface{}) (string, error) {
+	return api.request(ctx, endpoint, http.MethodGet, data)
 }
 
-func (api *Sms77API) post(endpoint string, data map[string]interface{}) (string, error) {
-	return api.request(endpoint, http.MethodPost, data)
+func (api *Sms77API) post(ctx context.Context, endpoint string, data map[string]interface{}) (string, error) {
+	return api.request(ctx, endpoint, http.MethodPost, data)
 }
 
-func (api *Sms77API) request(endpoint string, method string, data interface{}) (string, error) {
+func (api *Sms77API) request(ctx context.Context, endpoint string, method string, data interface{}) (string, error) {
 	createRequestPayload := func() string {
 		params := url.Values{}
 
@@ -177,7 +178,7 @@ func (api *Sms77API) request(endpoint string, method string, data interface{}) (
 			log.Printf("%s %s", method, uri)
 		}
 
-		req, err = http.NewRequest(method, uri, strings.NewReader(body))
+		req, err = http.NewRequestWithContext(ctx, method, uri, strings.NewReader(body))
 
 		if nil != err {
 			log.Println(err.Error())

--- a/sms77api/status.go
+++ b/sms77api/status.go
@@ -1,6 +1,7 @@
 package sms77api
 
 import (
+	"context"
 	"errors"
 	"strings"
 )
@@ -40,7 +41,10 @@ func makeStatus(res *string) (s *Status, e error) {
 const StatusApiCodeInvalidMessageId = "901"
 
 func (api *StatusResource) Text(p StatusParams) (*string, error) {
-	res, err := api.client.request("status", "POST", p)
+	return api.TextContext(context.Background(), p)
+}
+func (api *StatusResource) TextContext(ctx context.Context, p StatusParams) (*string, error) {
+	res, err := api.client.request(ctx, "status", "POST", p)
 
 	if err != nil {
 		return nil, err

--- a/sms77api/validate_for_voice.go
+++ b/sms77api/validate_for_voice.go
@@ -1,6 +1,9 @@
 package sms77api
 
-import "encoding/json"
+import (
+	"context"
+	"encoding/json"
+)
 
 type ValidateForVoiceParams struct {
 	Callback string `json:"callback"`
@@ -20,7 +23,11 @@ type ValidateForVoiceResponse struct {
 type ValidateForVoiceResource resource
 
 func (api *ValidateForVoiceResource) Get(p ValidateForVoiceParams) (o *ValidateForVoiceResponse, e error) {
-	r, e := api.client.request("validate_for_voice", "GET", p)
+	return api.GetContext(context.Background(), p)
+}
+
+func (api *ValidateForVoiceResource) GetContext(ctx context.Context, p ValidateForVoiceParams) (o *ValidateForVoiceResponse, e error) {
+	r, e := api.client.request(ctx, "validate_for_voice", "GET", p)
 
 	if nil != e {
 		return

--- a/sms77api/voice.go
+++ b/sms77api/voice.go
@@ -1,6 +1,7 @@
 package sms77api
 
 import (
+	"context"
 	"strconv"
 	"strings"
 )
@@ -36,7 +37,11 @@ func makeVoice(res string) Voice {
 }
 
 func (api *VoiceResource) Text(p VoiceParams) (*string, error) {
-	res, err := api.client.request("voice", "POST", p)
+	return api.TextContext(context.Background(), p)
+}
+
+func (api *VoiceResource) TextContext(ctx context.Context, p VoiceParams) (*string, error) {
+	res, err := api.client.request(ctx, "voice", "POST", p)
 
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
This is done in a backward compatible way, by adding additional methods.

E.g. on the VoiceResource another method TextContext, which takes an
additional context parameter was added.

```
func (api *VoiceResource) Text(p VoiceParams) (*string, error) {
	return api.TextContext(context.Background(), p)
}

func (api *VoiceResource) TextContext(ctx context.Context, p VoiceParams) (*string, error) {
```