### PR TITLE
Change the required Go version to v1.21

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 ## Installation
 
-Requires Go 1.17+.
+Requires Go 1.21+.
 
 ```go get github.com/seven-io/go-client/sms77api```
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/seven-io/go-client
 
-go 1.17
+go 1.21
 
 require github.com/stretchr/testify v1.10.0
 

--- a/sms77api/contacts.go
+++ b/sms77api/contacts.go
@@ -140,7 +140,7 @@ func (api *ContactsResource) ReadJsonContext(ctx context.Context, p ContactsRead
 		return
 	}
 
-	json.Unmarshal([]byte(s), &a)
+	e = json.Unmarshal([]byte(s), &a)
 
 	return
 }

--- a/sms77api/contacts_test.go
+++ b/sms77api/contacts_test.go
@@ -2,9 +2,11 @@ package sms77api
 
 import (
 	"fmt"
-	a "github.com/stretchr/testify/assert"
+	"slices"
 	"strings"
 	"testing"
+
+	a "github.com/stretchr/testify/assert"
 )
 
 var createdId uint64
@@ -46,7 +48,8 @@ func getDeleteParams() ContactsDeleteParams {
 }
 
 func isValidCode(needle ContactsWriteCode) bool {
-	return inArray(needle, [...]ContactsWriteCode{ContactsWriteCodeUnchanged, ContactsWriteCodeChanged})
+	validCodes := []ContactsWriteCode{ContactsWriteCodeUnchanged, ContactsWriteCodeChanged}
+	return slices.Contains(validCodes, needle)
 }
 
 func prepareEdit() (Contact, string) {

--- a/sms77api/sms77api.go
+++ b/sms77api/sms77api.go
@@ -198,23 +198,23 @@ func (api *Sms77API) request(ctx context.Context, endpoint string, method string
 		data = map[string]interface{}{}
 	}
 	data, _ = json.Marshal(&data)
-	json.Unmarshal(data.([]byte), &data)
+	_ = json.Unmarshal(data.([]byte), &data)
 
 	req, err := initClient()
 	if err != nil {
-		return "", fmt.Errorf("could not execute request! #1 (%s)", err.Error())
+		return "", fmt.Errorf("could not execute request! #1 (%w)", err)
 	}
 
 	res, err := api.client.Do(req)
 	if err != nil {
-		return "", fmt.Errorf("could not execute request! #2 (%s)", err.Error())
+		return "", fmt.Errorf("could not execute request! #2 (%w)", err)
 	}
 
 	defer res.Body.Close()
 
 	body, err := io.ReadAll(res.Body)
 	if err != nil {
-		return "", fmt.Errorf("could not execute request! #3 (%s)", err.Error())
+		return "", fmt.Errorf("could not execute request! #3 (%w)", err)
 	}
 
 	str := strings.TrimSpace(string(body))
@@ -226,8 +226,9 @@ func (api *Sms77API) request(ctx context.Context, endpoint string, method string
 	length := len(str)
 
 	if 2 == length || 3 == length {
-		code, msg := pickMapByKey(str, StatusCodes)
-		if nil != code {
+		code := StatusCode(str)
+
+		if msg, ok := StatusCodes[code]; ok {
 			return "", fmt.Errorf("%s: %s", code, msg)
 		}
 	}

--- a/sms77api/sms77api.go
+++ b/sms77api/sms77api.go
@@ -227,7 +227,6 @@ func (api *Sms77API) request(ctx context.Context, endpoint string, method string
 
 	if 2 == length || 3 == length {
 		code := StatusCode(str)
-
 		if msg, ok := StatusCodes[code]; ok {
 			return "", fmt.Errorf("%s: %s", code, msg)
 		}

--- a/sms77api/util.go
+++ b/sms77api/util.go
@@ -1,34 +1,8 @@
 package sms77api
 
 import (
-	"reflect"
 	"strconv"
 )
-
-func pickMapByKey(needle interface{}, haystack interface{}) (interface{}, interface{}) {
-	mapIter := reflect.ValueOf(haystack).MapRange()
-
-	for mapIter.Next() {
-		if needle == mapIter.Key() {
-			return needle, mapIter.Value()
-		}
-	}
-
-	return nil, nil
-}
-
-func inArray(needle interface{}, haystack interface{}) bool {
-	slice := reflect.ValueOf(haystack)
-	c := slice.Len()
-
-	for i := 0; i < c; i++ {
-		if needle == slice.Index(i).Interface() {
-			return true
-		}
-	}
-
-	return false
-}
 
 func toUint(id string, bitSize int) uint64 {
 	n, err := strconv.ParseUint(id, 10, bitSize)


### PR DESCRIPTION
As discussed in #2, the required Go version has been upgraded to v1.21. I have also changed a few lines in the code so that newer language features are used.