### PR TITLE
Fix: Voice response cannot be decoded

### DIFF
--- a/seven/voice.go
+++ b/seven/voice.go
@@ -3,10 +3,11 @@ package seven
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 )
 
 type VoiceHangupParams struct {
-	CallIdentifier string
+	CallIdentifier int64
 }
 
 type VoiceHangup struct {
@@ -25,7 +26,7 @@ type Voice struct {
 type VoiceMessage struct {
 	Error     *string `json:"error"`
 	ErrorText *string `json:"error_text"`
-	Id        *string `json:"id"`
+	Id        *int64  `json:"id"`
 	Price     float64 `json:"price"`
 	Recipient string  `json:"recipient"`
 	Sender    string  `json:"sender"`
@@ -67,7 +68,8 @@ func (api *VoiceResource) Hangup(p VoiceHangupParams) (o *VoiceHangup, e error) 
 }
 
 func (api *VoiceResource) HangupContext(ctx context.Context, p VoiceHangupParams) (*VoiceHangup, error) {
-	res, err := api.client.request(ctx, "voice/"+p.CallIdentifier+"/hangup", "POST", nil)
+	endpoint := fmt.Sprintf("voice/%d/hangup", p.CallIdentifier)
+	res, err := api.client.request(ctx, endpoint, "POST", nil)
 
 	if err != nil {
 		return nil, err

--- a/seven/voice_test.go
+++ b/seven/voice_test.go
@@ -1,8 +1,10 @@
 package seven
 
 import (
-	a "github.com/stretchr/testify/assert"
+	"encoding/json"
 	"testing"
+
+	a "github.com/stretchr/testify/assert"
 )
 
 func TestVoiceResource_Dispatch(t *testing.T) {
@@ -29,4 +31,52 @@ func TestVoiceResource_Dispatch(t *testing.T) {
 	} else {
 		a.Nil(t, v)
 	}
+}
+
+func TestVoice_UnmarshalJSON(t *testing.T) {
+	// The following example is taken from the API documentation and should be able to be transformed without errors.
+	// See: https://docs.seven.io/de/rest-api/endpunkte/voice
+	apiExample := []byte(`
+{
+  "success": "100",
+  "total_price": 0.045,
+  "balance": 3509.236,
+  "debug": false,
+  "messages": [
+    {
+      "id": 1384013,
+      "sender": "sender",
+      "recipient": "49176123456789",
+      "text": "Hallo Welt!",
+      "price": 0.045,
+      "success": true,
+      "error": null,
+      "error_text": null
+    }
+  ]
+}`)
+
+	js := &Voice{}
+	err := json.Unmarshal(apiExample, js)
+	if a.NoError(t, err) {
+		a.Len(t, js.Messages, 1)
+	}
+}
+
+func TestVoiceHangup_UnmarshalJSON(t *testing.T) {
+	// The following example is taken from the API documentation and should be able to be transformed without errors.
+	// See: https://docs.seven.io/de/rest-api/endpunkte/voice
+	apiExample := []byte(`
+{
+  "success": true,
+  "error": null
+}`)
+
+	js := &VoiceHangup{}
+	err := json.Unmarshal(apiExample, js)
+	if a.NoError(t, err) {
+		a.True(t, js.Success)
+		a.Nil(t, js.Error)
+	}
+
 }


### PR DESCRIPTION
Fix: The response for a voice call cannot be decoded because the message ID is a number and not a string.

I replaced the `string` with an `int64` value and added tests based on the API documentation to make sure everything works. 