### PR TITLE
Status codes updated

### DIFF
--- a/seven/api.go
+++ b/seven/api.go
@@ -94,12 +94,14 @@ var StatusCodes = map[StatusCode]string{
 	StatusCodeErrorServerIp:               "ErrorServerIp",
 }
 
+// StatusText returns a text for the SMS status code.
+// If the code is unknown, the string “Unknown” is returned.
 func StatusText(code StatusCode) string {
 	if msg, ok := StatusCodes[code]; ok {
 		return msg
 	}
 
-	return fmt.Sprintf("Unknown status code: %s", code)
+	return "Unknown"
 }
 
 func New(options Options) *API {

--- a/seven/api.go
+++ b/seven/api.go
@@ -69,6 +69,7 @@ const (
 	StatusCodeErrorCarrierDelivery        StatusCode = "600"
 	StatusCodeErrorUnknown                StatusCode = "700"
 	StatusCodeErrorAuthentication         StatusCode = "900"
+	StatusCodeErrorSigning                StatusCode = "901"
 	StatusCodeErrorApiDisabledForKey      StatusCode = "902"
 	StatusCodeErrorServerIp               StatusCode = "903"
 )
@@ -88,8 +89,17 @@ var StatusCodes = map[StatusCode]string{
 	StatusCodeErrorCarrierDelivery:        "ErrorCarrierDelivery",
 	StatusCodeErrorUnknown:                "ErrorUnknown",
 	StatusCodeErrorAuthentication:         "ErrorAuthentication",
+	StatusCodeErrorSigning:                "ErrorSigning",
 	StatusCodeErrorApiDisabledForKey:      "ErrorApiDisabledForKey",
 	StatusCodeErrorServerIp:               "ErrorServerIp",
+}
+
+func StatusText(code StatusCode) string {
+	if msg, ok := StatusCodes[code]; ok {
+		return msg
+	}
+
+	return fmt.Sprintf("Unknown status code: %s", code)
 }
 
 func New(options Options) *API {

--- a/seven/api_test.go
+++ b/seven/api_test.go
@@ -1,11 +1,21 @@
 package seven
 
 import (
-	a "github.com/stretchr/testify/assert"
 	"testing"
+
+	a "github.com/stretchr/testify/assert"
 )
 
 func TestNew(t *testing.T) {
 	a.IsType(t, client, &API{})
 	a.Exactly(t, testOptions, client.Options)
+}
+
+func TestStatusText(t *testing.T) {
+	text := StatusText(StatusCodeSuccess)
+	a.Equal(t, StatusCodes[StatusCodeSuccess], text)
+
+	unknownCode := StatusCode("000")
+	text = StatusText(unknownCode)
+	a.Contains(t, text, string(unknownCode))
 }

--- a/seven/api_test.go
+++ b/seven/api_test.go
@@ -15,7 +15,7 @@ func TestStatusText(t *testing.T) {
 	text := StatusText(StatusCodeSuccess)
 	a.Equal(t, StatusCodes[StatusCodeSuccess], text)
 
-	unknownCode := StatusCode("000")
+	unknownCode := StatusCode("00000")
 	text = StatusText(unknownCode)
-	a.Contains(t, text, string(unknownCode))
+	a.Equal(t, text, "Unknown")
 }

--- a/seven/voice.go
+++ b/seven/voice.go
@@ -23,14 +23,14 @@ type Voice struct {
 }
 
 type VoiceMessage struct {
-	Error     *string `json:"error"`
-	ErrorText *string `json:"error_text"`
-	Id        *string `json:"id"`
-	Price     float64 `json:"price"`
-	Recipient string  `json:"recipient"`
-	Sender    string  `json:"sender"`
-	Success   bool    `json:"success"`
-	Text      string  `json:"text"`
+	Error     *StatusCode `json:"error"`
+	ErrorText *string     `json:"error_text"`
+	Id        *string     `json:"id"`
+	Price     float64     `json:"price"`
+	Recipient string      `json:"recipient"`
+	Sender    string      `json:"sender"`
+	Success   bool        `json:"success"`
+	Text      string      `json:"text"`
 }
 
 type VoiceParams struct {

--- a/seven/voice.go
+++ b/seven/voice.go
@@ -18,7 +18,7 @@ type Voice struct {
 	Balance    float64        `json:"balance"`
 	Debug      bool           `json:"debug"`
 	TotalPrice float64        `json:"total_price"`
-	Success    string         `json:"success"`
+	Success    StatusCode     `json:"success"`
 	Messages   []VoiceMessage `json:"messages"`
 }
 


### PR DESCRIPTION
Added missing status code and a method to convert a status code into a string, similar to [`http.StatusText`](https://pkg.go.dev/net/http#StatusText)