### PR TITLE
Message ID can be a number or a string

### DIFF
--- a/seven/voice.go
+++ b/seven/voice.go
@@ -57,13 +57,15 @@ func (m *VoiceMessage) UnmarshalJSON(b []byte) error {
 		return errM
 	}
 
+	// This is a trick that prevents the object from referencing itself during encoding,
+	// which would result in an endless recursion.
 	type messageCopy VoiceMessage
-
 	var result messageCopy
 	if err := json.Unmarshal(b, &result); err != nil {
 		return err
 	}
 	*m = VoiceMessage(result)
+
 	return nil
 }
 

--- a/seven/voice.go
+++ b/seven/voice.go
@@ -45,7 +45,7 @@ func (m *VoiceMessage) UnmarshalJSON(b []byte) error {
 
 	switch idVal := data["id"].(type) {
 	case string:
-		if id, err := strconv.ParseInt(idVal, 0, 64); err != nil {
+		if id, err := strconv.ParseInt(idVal, 10, 64); err != nil {
 			return err
 		} else {
 			data["id"] = id

--- a/seven/voice.go
+++ b/seven/voice.go
@@ -3,10 +3,12 @@ package seven
 import (
 	"context"
 	"encoding/json"
+	"fmt"
+	"strconv"
 )
 
 type VoiceHangupParams struct {
-	CallIdentifier string
+	CallIdentifier int64
 }
 
 type VoiceHangup struct {
@@ -25,12 +27,44 @@ type Voice struct {
 type VoiceMessage struct {
 	Error     *string `json:"error"`
 	ErrorText *string `json:"error_text"`
-	Id        *string `json:"id"`
+	Id        *int64  `json:"id"`
 	Price     float64 `json:"price"`
 	Recipient string  `json:"recipient"`
 	Sender    string  `json:"sender"`
 	Success   bool    `json:"success"`
 	Text      string  `json:"text"`
+}
+
+// UnmarshalJSON is a workaround as a result of https://github.com/seven-io/go-client/issues/10.
+// The Id can be a string or a number and is converted into a number here.
+func (m *VoiceMessage) UnmarshalJSON(b []byte) error {
+	data := make(map[string]interface{}, 0)
+	if err := json.Unmarshal(b, &data); err != nil {
+		return err
+	}
+
+	switch idVal := data["id"].(type) {
+	case string:
+		if id, err := strconv.ParseInt(idVal, 0, 64); err != nil {
+			return err
+		} else {
+			data["id"] = id
+		}
+	}
+
+	b, errM := json.Marshal(data)
+	if errM != nil {
+		return errM
+	}
+
+	type messageCopy VoiceMessage
+
+	var result messageCopy
+	if err := json.Unmarshal(b, &result); err != nil {
+		return err
+	}
+	*m = VoiceMessage(result)
+	return nil
 }
 
 type VoiceParams struct {
@@ -67,7 +101,8 @@ func (api *VoiceResource) Hangup(p VoiceHangupParams) (o *VoiceHangup, e error) 
 }
 
 func (api *VoiceResource) HangupContext(ctx context.Context, p VoiceHangupParams) (*VoiceHangup, error) {
-	res, err := api.client.request(ctx, "voice/"+p.CallIdentifier+"/hangup", "POST", nil)
+	endpoint := fmt.Sprintf("voice/%d/hangup", p.CallIdentifier)
+	res, err := api.client.request(ctx, endpoint, "POST", nil)
 
 	if err != nil {
 		return nil, err

--- a/seven/voice_test.go
+++ b/seven/voice_test.go
@@ -1,8 +1,10 @@
 package seven
 
 import (
-	a "github.com/stretchr/testify/assert"
+	"encoding/json"
 	"testing"
+
+	a "github.com/stretchr/testify/assert"
 )
 
 func TestVoiceResource_Dispatch(t *testing.T) {
@@ -28,5 +30,28 @@ func TestVoiceResource_Dispatch(t *testing.T) {
 		client.Voice.Hangup(VoiceHangupParams{CallIdentifier: *msg.Id})
 	} else {
 		a.Nil(t, v)
+	}
+}
+
+func TestVoiceMessage_UnmarshalJSON(t *testing.T) {
+	expectedNumber := int64(1384013)
+	tests := []struct {
+		name     string
+		data     []byte
+		excepted *int64
+	}{
+		{"IdIsString", []byte(`{"id": "1384013"}`), &expectedNumber},
+		{"IdIsNumber", []byte(`{"id": 1384013}`), &expectedNumber},
+		{"IdIsNil", []byte(`{"id": null}`), nil},
+		{"IdIsMissing", []byte(`{}`), nil},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			msg := &VoiceMessage{}
+			err := json.Unmarshal(test.data, &msg)
+			a.NoError(t, err)
+			a.Equal(t, test.excepted, msg.Id)
+		})
 	}
 }

--- a/seven/voice_test.go
+++ b/seven/voice_test.go
@@ -51,8 +51,9 @@ func TestVoiceMessage_UnmarshalJSON(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			msg := &VoiceMessage{}
 			err := json.Unmarshal(test.data, &msg)
-			a.NoError(t, err)
-			a.Equal(t, test.excepted, msg.Id)
+			if a.NoError(t, err) {
+				a.Equal(t, test.excepted, msg.Id)
+			}
 		})
 	}
 }

--- a/seven/voice_test.go
+++ b/seven/voice_test.go
@@ -41,10 +41,10 @@ func TestVoiceMessage_UnmarshalJSON(t *testing.T) {
 		data     []byte
 		excepted *int64
 	}{
-		{"id=\"1384013\"", []byte(`{"id": "1384013"}`), &expectedNumber},
-		{"id=1384013", []byte(`{"id": 1384013}`), &expectedNumber},
-		{"id=nil", []byte(`{"id": null}`), nil},
-		{"id=missing", []byte(`{}`), nil},
+		{`id="1384013"`, []byte(`{"id": "1384013"}`), &expectedNumber},
+		{`id=1384013`, []byte(`{"id": 1384013}`), &expectedNumber},
+		{`id=nil`, []byte(`{"id": null}`), nil},
+		{`id=missing`, []byte(`{}`), nil},
 	}
 
 	for _, test := range tests {

--- a/seven/voice_test.go
+++ b/seven/voice_test.go
@@ -19,8 +19,9 @@ func TestVoiceResource_Dispatch(t *testing.T) {
 
 		if testIsDummy {
 			a.Equal(t, "100", v.Success)
-			a.Equal(t, 0, msg.Id)
-			a.Equal(t, 0, v.TotalPrice)
+			exceptedId := int64(123456789)
+			a.Equal(t, &exceptedId, msg.Id)
+			a.Equal(t, 0.0, v.TotalPrice)
 		} else {
 			a.NotEmpty(t, v.Success)
 			a.NotEmpty(t, msg.Id)

--- a/seven/voice_test.go
+++ b/seven/voice_test.go
@@ -41,10 +41,10 @@ func TestVoiceMessage_UnmarshalJSON(t *testing.T) {
 		data     []byte
 		excepted *int64
 	}{
-		{"IdIsString", []byte(`{"id": "1384013"}`), &expectedNumber},
-		{"IdIsNumber", []byte(`{"id": 1384013}`), &expectedNumber},
-		{"IdIsNil", []byte(`{"id": null}`), nil},
-		{"IdIsMissing", []byte(`{}`), nil},
+		{"id=\"1384013\"", []byte(`{"id": "1384013"}`), &expectedNumber},
+		{"id=1384013", []byte(`{"id": 1384013}`), &expectedNumber},
+		{"id=nil", []byte(`{"id": null}`), nil},
+		{"id=missing", []byte(`{}`), nil},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
This PR adds a workaround for #10 so that both strings and numbers can be processed as IDs. 

For this purpose, the [Unmarshaler interface](https://pkg.go.dev/encoding/json#Unmarshaler) is implemented, and a `string` is converted into an `int64` value if necessary.

As soon as #10 is fixed, the method should be removed again.