### PR TITLE
Fix group tests

### DIFF
--- a/seven/groups.go
+++ b/seven/groups.go
@@ -25,7 +25,13 @@ type GroupOrderParams struct {
 	PaymentInterval PaymentInterval `json:"payment_interval"`
 }
 
+type GroupCreateParams struct {
+	// Name of the group
+	Name string `json:"name"`
+}
+
 type GroupUpdateParams struct {
+	// Name is the new name of the group.
 	Name string `json:"name"`
 }
 
@@ -58,7 +64,7 @@ func (api *GroupsResource) GetContext(ctx context.Context, p GroupsGetParams) (c
 		return
 	}
 
-	json.Unmarshal([]byte(s), &c)
+	e = json.Unmarshal([]byte(s), &c)
 
 	return
 }
@@ -74,20 +80,22 @@ func (api *GroupsResource) ListContext(ctx context.Context, p GroupsListParams) 
 		return
 	}
 
-	json.Unmarshal([]byte(s), &a)
+	e = json.Unmarshal([]byte(s), &a)
 
 	return
 }
 
-func (api *GroupsResource) Create(p GroupOrderParams) (c Group, e error) {
+func (api *GroupsResource) Create(p GroupCreateParams) (c Group, e error) {
 	return api.CreateContext(context.Background(), p)
 }
 
-func (api *GroupsResource) CreateContext(ctx context.Context, p GroupOrderParams) (c Group, e error) {
+func (api *GroupsResource) CreateContext(ctx context.Context, p GroupCreateParams) (c Group, e error) {
 	s, e := api.client.request(ctx, "groups", string(HttpMethodPost), p)
+	if e != nil {
+		return
+	}
 
 	e = json.Unmarshal([]byte(s), &c)
-
 	return
 }
 
@@ -97,6 +105,9 @@ func (api *GroupsResource) Delete(p GroupsDeleteParams) (o GroupsDeleteResponse,
 
 func (api *GroupsResource) DeleteContext(ctx context.Context, p GroupsDeleteParams) (o GroupsDeleteResponse, e error) {
 	s, e := api.client.request(ctx, fmt.Sprintf("groups/%d", p.ID), string(HttpMethodDelete), p)
+	if e != nil {
+		return
+	}
 
 	e = json.Unmarshal([]byte(s), &o)
 

--- a/seven/groups.go
+++ b/seven/groups.go
@@ -20,11 +20,6 @@ type Group struct {
 	ID           uint   `json:"id"`
 }
 
-type GroupOrderParams struct {
-	Number          string          `json:"number"`
-	PaymentInterval PaymentInterval `json:"payment_interval"`
-}
-
 type GroupCreateParams struct {
 	// Name of the group
 	Name string `json:"name"`

--- a/seven/groups_test.go
+++ b/seven/groups_test.go
@@ -1,45 +1,43 @@
 package seven
 
 import (
-	a "github.com/stretchr/testify/assert"
 	"testing"
+
+	a "github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestGroups(t *testing.T) {
 	created, e := client.Groups.Create(GroupCreateParams{
 		Name: "MyGroup",
 	})
-	if e != nil {
-		t.Errorf(e.Error())
-	}
+	require.NoError(t, e)
 
 	list, e := client.Groups.List(GroupsListParams{
 		Limit:  nil,
 		Offset: nil,
 	})
-	if e != nil {
-		t.Errorf(e.Error())
+	if a.NoError(t, e) {
+		a.NotEmpty(t, list.Data)
+		a.Contains(t, list.Data, created)
 	}
-	a.NotEmpty(t, list.Data)
 
 	updateParams := GroupUpdateParams{
 		Name: "MyNewGroupName",
 	}
 	e = client.Groups.Update(created.ID, updateParams)
-	if e != nil {
-		t.Errorf(e.Error())
-	}
+	a.NoError(t, e)
 
 	group, e := client.Groups.Get(GroupsGetParams{ID: created.ID})
-	if e != nil {
-		t.Errorf(e.Error())
+	if a.NoError(t, e) {
+		a.NotNil(t, group)
+		a.NotEqual(t, created.Name, group.Name)
+		a.Equal(t, updateParams.Name, group.Name)
+		a.Equal(t, created.ID, group.ID)
 	}
-	a.NotNil(t, group)
-	a.NotEqual(t, created.Name, group.Name)
 
 	deleted, e := client.Groups.Delete(GroupsDeleteParams{ID: group.ID, DeleteContacts: false})
-	if e != nil {
-		t.Errorf(e.Error())
+	if a.NoError(t, e) {
+		a.True(t, deleted.Success)
 	}
-	a.True(t, deleted.Success)
 }


### PR DESCRIPTION
The group tests could not be executed currently because fields were used that do not exist.

I have added the struct `GroupCreateParams`, which is used to create groups. I removed the struct `GroupOrderParams` because it belongs to the Numbers endpoint. 